### PR TITLE
Do align for final row of grid

### DIFF
--- a/Core/Widgets/Grid.cs
+++ b/Core/Widgets/Grid.cs
@@ -253,6 +253,7 @@ public class Grid : View
         var secondaryUsed = 0.0f;
         var position = Vector2.Zero;
         int currentCount = 0;
+        int totalCount = Children.Count;
         var maxSecondary = 0.0f;
         int laneStartIndex = 0;
         secondaryStartPositions.Clear();
@@ -266,7 +267,7 @@ public class Grid : View
             childPositions.Add(new(child, position));
             currentCount++;
             maxSecondary = MathF.Max(maxSecondary, secondaryOrientation.Get(child.OuterSize));
-            if (currentCount >= countBeforeWrap)
+            if ((currentCount > 0 && currentCount % countBeforeWrap == 0) || currentCount == totalCount)
             {
                 var cellBounds = childLimits;
                 // Limits will have the primary dimension be the actual length, but secondary dimension is the full
@@ -292,7 +293,6 @@ public class Grid : View
                 secondaryAvailable -= maxSecondary + secondarySpacing;
                 secondaryStartPositions.Add(secondaryUsed);
                 maxSecondary = 0;
-                currentCount = 0;
                 laneStartIndex = childPositions.Count;
             }
             else

--- a/Core/Widgets/Grid.cs
+++ b/Core/Widgets/Grid.cs
@@ -253,13 +253,13 @@ public class Grid : View
         var secondaryUsed = 0.0f;
         var position = Vector2.Zero;
         int currentCount = 0;
-        int totalCount = Children.Count;
         var maxSecondary = 0.0f;
         int laneStartIndex = 0;
         secondaryStartPositions.Clear();
         secondaryStartPositions.Add(0);
-        foreach (var child in Children)
+        for (int childIdx = 0; childIdx < Children.Count; childIdx++)
         {
+            var child = Children[childIdx];
             var childLimits = Vector2.Zero;
             PrimaryOrientation.Set(ref childLimits, itemLength);
             secondaryOrientation.Set(ref childLimits, secondaryAvailable);
@@ -267,7 +267,7 @@ public class Grid : View
             childPositions.Add(new(child, position));
             currentCount++;
             maxSecondary = MathF.Max(maxSecondary, secondaryOrientation.Get(child.OuterSize));
-            if ((currentCount > 0 && currentCount % countBeforeWrap == 0) || currentCount == totalCount)
+            if (currentCount >= countBeforeWrap || childIdx == Children.Count - 1)
             {
                 var cellBounds = childLimits;
                 // Limits will have the primary dimension be the actual length, but secondary dimension is the full
@@ -293,6 +293,7 @@ public class Grid : View
                 secondaryAvailable -= maxSecondary + secondarySpacing;
                 secondaryStartPositions.Add(secondaryUsed);
                 maxSecondary = 0;
+                currentCount = 0;
                 laneStartIndex = childPositions.Count;
             }
             else


### PR DESCRIPTION
Fixes issue #20

Test view:

```
<frame layout="640px 640px" background={@Mods/StardewUI/Sprites/ControlBorder} margin="0,16,0,0" padding="32,24">
  <scrollable peeking="128">
    <grid layout="stretch content" item-layout="count: 6" horizontal-item-alignment="middle">
      <image layout="stretch content" *repeat={Items} sprite={this} tooltip={:DisplayName} focusable="true" layout="64px 64px"/>
    </grid>
  </scrollable>
</frame>
```

Without the change in this PR, the last row becomes aligned only if it has exactly same number of items as row size.