### PR TITLE
Use upper and lower invariant for ToUpperCamelCase

### DIFF
--- a/Framework/Binding/TextExtensions.cs
+++ b/Framework/Binding/TextExtensions.cs
@@ -29,12 +29,12 @@ internal static class TextExtensions
             }
             if (capitalizeNext)
             {
-                sb.Append(Rune.ToUpper(rune, CultureInfo.CurrentUICulture));
+                sb.Append(Rune.ToUpperInvariant(rune));
                 capitalizeNext = false;
             }
             else
             {
-                sb.Append(Rune.ToLower(rune, CultureInfo.CurrentUICulture));
+                sb.Append(Rune.ToLowerInvariant(rune));
             }
         }
         return sb.ToString();


### PR DESCRIPTION
Log: https://smapi.io/log/57b9b049c3a649569ae83914f5d4aa61

```
Failed to update node:

  <grid item-layout="length: 192" horizontal-item-alignment="middle"/>

StardewUI.Framework.Descriptors.DescriptorException: Type Grid does not have a property named 'İtemLayout'.
   at StardewUI.Framework.Descriptors.IObjectDescriptor.GetProperty(String name) in D:\Repo\StardewUI\Framework\Descriptors\IObjectDescriptor.cs:line 73
   at StardewUI.Framework.Binding.AttributeBindingFactory.TryCreateBinding(IViewDescriptor viewDescriptor, IAttribute attribute, BindingContext context, IResolutionScope resolutionScope) in D:\Repo\StardewUI\Framework\Binding\AttributeBindingFactory.cs:line 169
   at StardewUI.Framework.Binding.ReflectionViewBinder.<>c__DisplayClass3_0.<Bind>b__1(IAttribute attribute) in D:\Repo\StardewUI\Framework\Binding\ReflectionViewBinder.cs:line 30
```

Issue where `item-layout` became `İtemLayout` after camel casing.

Test build: 
[StardewUI 0.6.1.zip](https://github.com/user-attachments/files/19744617/StardewUI.0.6.1.zip)
